### PR TITLE
sync

### DIFF
--- a/chapter01/changelog.xml
+++ b/chapter01/changelog.xml
@@ -42,7 +42,40 @@
     <listitem revision="sysv"> or <listitem revision="systemd"> as
     appropriate for the entry or if needed the entire day's listitem.
 -->
-<listitem>
+
+ <listitem>
+      <para>2018-09-20</para>
+      <itemizedlist>
+        <listitem>
+          <para>[bdubbs] - Очистка от ненужных символических ссылок.
+			 Изменён порядок сборки пакетов, зависящих от версии. В 6 главе, сборка происходит как можно позднее. В 5 главе, сборка util-linux более не требуется. Удалено.
+          Исправления <ulink url="&lfs-ticket-root;4345">#4345</ulink> и
+          <ulink url="&lfs-ticket-root;4349">#4349</ulink>.</para>
+        </listitem>
+        <listitem revision='sysv'>
+          <para>[bdubbs] - Обновлено до версии eudev-3.2.6. Исправления
+          <ulink url="&lfs-ticket-root;4350">#4350</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Обновлено до версии elfutils-0.174 (libelf). Исправления
+          <ulink url="&lfs-ticket-root;4348">#4348</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Обновлено до версии psmisc-23.2. Исправления
+          <ulink url="&lfs-ticket-root;4347">#4347</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Обновлено до версии openssl-1.1.1. Исправления
+          <ulink url="&lfs-ticket-root;4346">#4346</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[bdubbs] - Обновлено до версии linux-4.18.9. Исправления
+          <ulink url="&lfs-ticket-root;4344">#4344</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+	<listitem>
       <para>2018-09-02</para>
       <itemizedlist>
         <listitem>

--- a/chapter01/whatsnew.xml
+++ b/chapter01/whatsnew.xml
@@ -67,9 +67,9 @@
     <!--<listitem>
       <para>Diffutils-&diffutils-version;</para>
     </listitem>-->
-    <!--<listitem revision="sysv">
+    <listitem revision="sysv">
       <para>Eudev-&eudev-version;</para>
-   </listitem>-->
+   </listitem>
    <listitem>
       <para>E2fsprogs-&e2fsprogs-version;</para>
    </listitem>
@@ -148,18 +148,18 @@
     <!--<listitem>
       <para>Libcap-&libcap-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Libelf-&elfutils-version;</para>
-   </listitem>-->
+   </listitem>
    <!--<listitem>
       <para>Libpipeline-&libpipeline-version;</para>
    </listitem>-->
     <!--<listitem>
       <para>Libtool-&libtool-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Linux-&linux-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>M4-&m4-version;</para>
     </listitem>-->
@@ -184,9 +184,9 @@
    <!--<listitem>
       <para>Ncurses-&ncurses-version;</para>
    </listitem>-->
-   <!--<listitem>
+   <listitem>
       <para>Openssl-&openssl-version;</para>
-   </listitem>-->
+   </listitem>
    <!-- <listitem>
       <para>Patch-&patch-version;</para>
    </listitem>-->
@@ -199,9 +199,9 @@
     <!--<listitem>
       <para>Procps-ng-&procps-ng-version;</para>
     </listitem>-->
-    <!--<listitem>
+    <listitem>
       <para>Psmisc-&psmisc-version;</para>
-    </listitem>-->
+    </listitem>
     <!--<listitem>
       <para>Python-&python-version;</para>
     </listitem>-->

--- a/chapter05/chapter05.xml
+++ b/chapter05/chapter05.xml
@@ -44,7 +44,7 @@
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="sed.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="tar.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="texinfo.xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="util-linux.xml"/>
+  <!-- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="util-linux.xml"/> -->
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="xz.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="stripping.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="changingowner.xml"/>

--- a/chapter05/make.xml
+++ b/chapter05/make.xml
@@ -42,7 +42,7 @@
   <sect2 role="installation">
     <title>Установка пакета Make</title>
 
-    <para>Для начала, необходимо обойти ошибку, вызванную glibc-2.27:</para>
+    <para>Для начала, необходимо обойти ошибку, из-за  glibc-2.27 и более поздних версиях:</para>
 
 <screen><userinput remap="pre">sed -i '211,217 d; 219,229 d; 232 d' glob/glob.c</userinput></screen>
 

--- a/chapter06/chapter06.xml
+++ b/chapter06/chapter06.xml
@@ -39,7 +39,6 @@
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="acl.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="libcap.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="sed.xml"/>
-  <!-- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="shadow.xml"/> -->
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="psmisc.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="iana-etc.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="bison.xml"/>
@@ -65,12 +64,6 @@
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="python.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="ninja.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="meson.xml"/>
-
-  <!-- systemd only -->
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="systemd.xml"/>
-
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="procps.xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="e2fsprogs.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="coreutils.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="check.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="diffutils.xml"/>
@@ -85,20 +78,24 @@
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="libpipeline.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="make.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="patch.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="util-linux.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="e2fsprogs.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="man-db.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="tar.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="texinfo.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="vim.xml"/>
 
   <!-- systemd only -->
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="systemd.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="dbus.xml"/>
+  <!-- props needs libsystemd -->
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="procps.xml"/>
 
   <!-- sysv only -->
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="sysklogd.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="sysvinit.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="eudev.xml"/>
 
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="util-linux.xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="man-db.xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="tar.xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="texinfo.xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="vim.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="aboutdebug.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="strippingagain.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="revisedchroot.xml"/>

--- a/chapter06/createfiles.xml
+++ b/chapter06/createfiles.xml
@@ -35,41 +35,31 @@
   </indexterm>
 
   <para>Некоторые программы используют жестко зашитые пути к другим программам, которые еще не установлены. Чтобы скорректировать этот недостаток, требуется создать ряд символических ссылок, которые
-   будут заменены реальными файлами на протяжении установки программ в этой главе.</para>
-<!--
-<screen revision="sysv"><userinput>ln -sv /tools/bin/{bash,cat,dd,echo,ln,pwd,rm,stty} /bin
-ln -sv /tools/bin/{install,perl} /usr/bin
-ln -sv /tools/lib/libgcc_s.so{,.1} /usr/lib
-ln -sv /tools/lib/libstdc++.{a,so{,.6}} /usr/lib
-ln -sv bash /bin/sh
-
-</userinput></screen>-->
-<!--sed 's/tools/usr/' /tools/lib/libstdc++.la > /usr/lib/libstdc++.la -->
-
-<!--<screen revision="systemd"><userinput>ln -sv /tools/bin/{bash,cat,dd,echo,ln,pwd,rm,stty} /bin-->
+   будут заменены реальными файлами в процессе установки программ в этой главе.</para>
 <screen><userinput>ln -sv /tools/bin/{bash,cat,dd,echo,ln,pwd,rm,stty} /bin
-ln -sv /tools/bin/{env,install,perl} /usr/bin
-ln -sv /tools/lib/libgcc_s.so{,.1} /usr/lib
-ln -sv /tools/lib/libstdc++.{a,so{,.6}} /usr/lib
-for lib in blkid lzma mount uuid
+ln -sv /tools/bin/{env,install,perl}                /usr/bin
+ln -sv /tools/lib/libgcc_s.so{,.1}                  /usr/lib
+ln -sv /tools/lib/libstdc++.{a,so{,.6}}             /usr/lib
+
+install -vdm755 /usr/lib/pkgconfig
+
+ln -sv bash /bin/sh</userinput></screen>
+
+<!--for lib in blkid lzma mount uuid
 do
     ln -sv /tools/lib/lib$lib.so* /usr/lib
-done
-ln -svf /tools/include/blkid    /usr/include
+done-->
+<!--ln -svf /tools/include/blkid    /usr/include
 ln -svf /tools/include/libmount /usr/include
-ln -svf /tools/include/uuid     /usr/include
-install -vdm755 /usr/lib/pkgconfig
-for pc in blkid mount uuid
+ln -svf /tools/include/uuid     /usr/include-->
+<!--for pc in blkid mount uuid
 do
     sed 's@tools@usr@g' /tools/lib/pkgconfig/${pc}.pc \
         > /usr/lib/pkgconfig/${pc}.pc
-done
-ln -sv bash /bin/sh</userinput></screen>
+done-->
 
-<!--sed 's/tools/usr/' /tools/lib/libstdc++.la > /usr/lib/libstdc++.la
-   sed 's/tools/usr/' /tools/lib/lib${lib}.la > /usr/lib/lib${lib}.la-->
   <variablelist>
-    <title>Описание ссылок</title>
+    <title>Описание каждоый ссылки</title>
 
     <varlistentry>
       <term><parameter><filename>/bin/bash</filename></parameter></term>
@@ -99,6 +89,15 @@ ln -sv bash /bin/sh</userinput></screen>
       <listitem>
         <para>Используется для тестирования Glibc. Наборам тестов требуется
         <filename>/bin/echo</filename>.</para>
+      </listitem>
+    </varlistentry>
+
+	 <varlistentry>
+      <term><parameter><filename>/usr/bin/env</filename></parameter></term>
+      <listitem>
+        <para>
+		  Этот путь жестко зашит в процедуры сборки некоторых пакетов
+        <!-- systemd  This may not be needed if we move sysd to the end--></para>
       </listitem>
     </varlistentry>
 
@@ -174,7 +173,7 @@ ln -sv bash /bin/sh</userinput></screen>
       </listitem>
     </varlistentry>
 -->
-    <!--<varlistentry revision="systemd">-->
+    <!--<varlistentry revision="systemd">
 	 <varlistentry>
       <term><parameter><filename>/usr/lib/lib{blkid,lzma,mount,uuid}.{a,la,so*}</filename></parameter></term>
       <listitem>
@@ -182,7 +181,7 @@ ln -sv bash /bin/sh</userinput></screen>
         <filename class="directory">/tools</filename>.</para>
       </listitem>
     </varlistentry>
-
+-->
     <varlistentry>
       <term><parameter><filename>/bin/sh</filename></parameter></term>
       <listitem>

--- a/chapter06/e2fsprogs.xml
+++ b/chapter06/e2fsprogs.xml
@@ -110,11 +110,13 @@ PKG_CONFIG_PATH=/tools/lib/pkgconfig \
 
 <screen><userinput remap="make">make</userinput></screen>
 
-    <para>Для выполнения тестов, нужно сначала создать некоторые символические ссылки на библиотеки из каталога
-	 /tools/lib куда ссылаются программы тестирования.Для выполнения тестов, выполните следующую команду:</para>
+    <!--<para>Для выполнения тестов, нужно сначала создать некоторые символические ссылки на библиотеки из каталога
+	 /tools/lib куда ссылаются программы тестирования.Для выполнения тестов, выполните следующую команду:</para>-->
+<para>Для выполнения тестов, выполните команду:</para>
+<screen><userinput remap="test">make check</userinput></screen>
 
-<screen><userinput remap="test">ln -sfv /tools/lib/lib{blk,uu}id.so.1 lib
-make LD_LIBRARY_PATH=/tools/lib check</userinput></screen>
+<!-- <screen><userinput remap="test">ln -sfv /tools/lib/lib{blk,uu}id.so.1 lib
+make LD_LIBRARY_PATH=/tools/lib check</userinput></screen> -->
 
     <para>Один из тестов пакета E2fsprogs попытается выделить 256 MB памяти. Если у вас нет такого объема оперативной памяти, не забудьте включить требуемое пространство в файл подкачки для выполнения теста. Смотрите  <xref
     linkend="space-creatingfilesystem"/> и <xref linkend="space-mounting"/>

--- a/chapter06/libelf.xml
+++ b/chapter06/libelf.xml
@@ -14,7 +14,7 @@
     <address>&elfutils-url;</address>
   </sect1info>
 
-  <title>Libelf &elfutils-version;</title>
+  <title>Libelf из пакета Elfutils-&elfutils-version;</title>
 
   <indexterm zone="ch-system-libelf">
     <primary sortas="a-Libelf">Libelf</primary>

--- a/chapter06/make.xml
+++ b/chapter06/make.xml
@@ -42,7 +42,7 @@
   <sect2 role="installation">
     <title>Установка пакета Make</title>
 
-    <para>Необходимо обойти ошибку, вызванную glibc-2.27:</para>
+    <para>Необходимо обойти ошибку, вызванную glibc-2.27 и в более поздних версиях:</para>
 
 <screen><userinput remap="pre">sed -i '211,217 d; 219,229 d; 232 d' glob/glob.c</userinput></screen>
     <para>Подготовьте пакет Make к компиляции:</para>

--- a/general.ent
+++ b/general.ent
@@ -1,13 +1,13 @@
-<!ENTITY version         "20180902">
+<!ENTITY version         "20180920">
 <!ENTITY short-version   "8.2">  <!-- Used below in &blfs-book;
                                       Change to x.y for release but not -rc releases -->
 <!ENTITY generic-version "development"> <!-- Use "development"  or "x.y[-pre{x}]" -->
 
-<!ENTITY versiond        "20180902-systemd">
+<!ENTITY versiond        "20180920-systemd">
 <!ENTITY short-versiond  "systemd">
 <!ENTITY generic-versiond "systemd">
 
-<!ENTITY releasedate     "2 Сентября, 2018">
+<!ENTITY releasedate     "20 Сентября, 2018">
 
 <!ENTITY copyrightdate   "1999-2018"><!-- jhalfs needs a literal dash, not &ndash; -->
 <!ENTITY milestone       "8.3">

--- a/packages.ent
+++ b/packages.ent
@@ -142,18 +142,18 @@
 <!ENTITY e2fsprogs-ch6-du "96 MB">
 <!ENTITY e2fsprogs-ch6-sbu "1.6 SBU">
 
-<!ENTITY elfutils-version "0.173">
-<!ENTITY elfutils-size "8,482 KB">
+<!ENTITY elfutils-version "0.174">
+<!ENTITY elfutils-size "8,497 KB">
 <!ENTITY elfutils-url "https://sourceware.org/ftp/elfutils/&elfutils-version;/elfutils-&elfutils-version;.tar.bz2">
-<!ENTITY elfutils-md5 "35decb1ebfb90d565e4c411bee4185cc">
+<!ENTITY elfutils-md5 "48bec24c0c8b2c16820326956dff9378">
 <!ENTITY elfutils-home "https://sourceware.org/ftp/elfutils/">
 <!ENTITY elfutils-ch6-du "91 MB">
 <!ENTITY elfutils-ch6-sbu "1.0 SBU">
 
-<!ENTITY eudev-version "3.2.5">
-<!ENTITY eudev-size "1,814">
+<!ENTITY eudev-version "3.2.6">
+<!ENTITY eudev-size "1,849 KB">
 <!ENTITY eudev-url "https://dev.gentoo.org/~blueness/eudev/eudev-&eudev-version;.tar.gz">
-<!ENTITY eudev-md5 "6ca08c0e14380f87df8e8aceac123671">
+<!ENTITY eudev-md5 "902c4cdc9235838067cc69978a780e72">
 <!ENTITY eudev-ch6-du "81 MB">
 <!ENTITY eudev-ch6-sbu "0.2 SBU">
 
@@ -413,12 +413,12 @@
 
 <!ENTITY linux-major-version "4">
 <!ENTITY linux-minor-version "18">
-<!ENTITY linux-patch-version "5">
+<!ENTITY linux-patch-version "9">
 <!--<!ENTITY linux-version "&linux-major-version;.&linux-minor-version;"> -->
 <!ENTITY linux-version "&linux-major-version;.&linux-minor-version;.&linux-patch-version;">
-<!ENTITY linux-size "99,411 KB">
+<!ENTITY linux-size "99,413 KB">
 <!ENTITY linux-url "&kernel;linux/kernel/v&linux-major-version;.x/linux-&linux-version;.tar.xz">
-<!ENTITY linux-md5 "22851fe6c82db6673a844bbb7c62df67">
+<!ENTITY linux-md5 "6f082741ab20f03a334fe533d533880e">
 <!ENTITY linux-home "https://www.kernel.org/">
 <!-- measured for 4.8.3 / gcc-6.2.0 on x86_64 : minimum is
  allnoconfig extended for a hopefully-bootable build on desktop machine,
@@ -509,10 +509,10 @@
 <!ENTITY ninja-ch6-du "83 MB">
 <!ENTITY ninja-ch6-sbu "0.2 SBU">
 
-<!ENTITY openssl-version "1.1.0h">
-<!ENTITY openssl-size "5,296 KB">
+<!ENTITY openssl-version "1.1.1">
+<!ENTITY openssl-size "8,143 KB">
 <!ENTITY openssl-url "https://openssl.org/source/openssl-&openssl-version;.tar.gz">
-<!ENTITY openssl-md5 "5271477e4d93f4ea032b665ef095ff24">
+<!ENTITY openssl-md5 "7079eb017429e0ffb9efb42bf80ccb21">
 <!ENTITY openssl-home "https://www.openssl.org/">
 <!ENTITY openssl-ch6-du "75 MB">
 <!ENTITY openssl-ch6-sbu "1.7 SBU">
@@ -553,13 +553,14 @@
 <!ENTITY procps-ng-ch6-du "17 MB">
 <!ENTITY procps-ng-ch6-sbu "0.1 SBU">
 
-<!ENTITY psmisc-version "23.1">
-<!ENTITY psmisc-size "290 KB">
-<!ENTITY psmisc-url "https://sourceforge.net/projects/psmisc/files/psmisc/psmisc-&psmisc-version;.tar.xz">
-<!ENTITY psmisc-md5 "bbba1f701c02fb50d59540d1ff90d8d1">
+<!ENTITY psmisc-version "23.2">
+<!ENTITY psmisc-size "292 KB">
+<!ENTITY psmisc-url "https://sourceforge.net/projects/psmisc/files/psmisc&#37;20devel/psmisc-&psmisc-version;.tar.xz">
+<!-- &#37; is a percent sign - results in %20 (a space in a URL -->
+<!ENTITY psmisc-md5 "17b72c193b090f379fedf573123e89b8">
 <!ENTITY psmisc-home "http://psmisc.sourceforge.net/">
 <!ENTITY psmisc-ch6-du "4.3 MB">
-<!ENTITY psmisc-ch6-sbu "менее чем 0.1 SBU">
+<!ENTITY psmisc-ch6-sbu "less than 0.1 SBU">
 
 <!-- If python minor version changes, updates in python and
      meson pages will be needed: python3.6 and python3.6m -->


### PR DESCRIPTION
Revision: 11472
Author: bdubbs
Date: 20 сентября 2018 г. 20:02:36
Message:
Clean up of unneeded symbolic links.
Reordered packages so version specific packages are
built as late as possible in Chapter 6. Now building
util-linux in Chapter 5 is unneeded and has been removed.

Update to eudev-3.2.6.
Update to elfutils-0.174 (libelf).
Update to psmisc-23.2.
Update to openssl-1.1.1.
Update to linux-4.18.9.

----
Modified : /trunk/BOOK/chapter01/changelog.xml
Modified : /trunk/BOOK/chapter01/whatsnew.xml
Modified : /trunk/BOOK/chapter05/chapter05.xml
Modified : /trunk/BOOK/chapter05/make.xml
Modified : /trunk/BOOK/chapter06/chapter06.xml
Modified : /trunk/BOOK/chapter06/createfiles.xml
Modified : /trunk/BOOK/chapter06/e2fsprogs.xml
Modified : /trunk/BOOK/chapter06/libelf.xml
Modified : /trunk/BOOK/chapter06/make.xml
Modified : /trunk/BOOK/general.ent
Modified : /trunk/BOOK/packages.ent


