### PR TITLE
/trunk/BOOK/general.ent

### DIFF
--- a/chapter01/changelog.xml
+++ b/chapter01/changelog.xml
@@ -43,6 +43,19 @@
     appropriate for the entry or if needed the entire day's listitem.
 -->
 
+<listitem>
+      <para>2018-09-30</para>
+      <itemizedlist>
+        <listitem revision="systemd">
+          <para>[dj] - Возобновлена сборка пакета Util-Linux в главе 5 чтобы избежать взаимной зависимости для Systemd.</para>
+        </listitem>
+        <listitem>
+          <para>[dj] - Установка Util-Linux и E2fsprogs перенесены после Procps для правильного порядка сборки в книге Systemd. Редакцию SysV - не затрагивает.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+
  <listitem>
       <para>2018-09-20</para>
       <itemizedlist>

--- a/chapter05/chapter05.xml
+++ b/chapter05/chapter05.xml
@@ -44,7 +44,7 @@
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="sed.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="tar.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="texinfo.xml"/>
-  <!-- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="util-linux.xml"/> -->
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="util-linux.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="xz.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="stripping.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="changingowner.xml"/>

--- a/chapter05/util-linux.xml
+++ b/chapter05/util-linux.xml
@@ -5,7 +5,7 @@
   %general-entities;
 ]>
 
-<sect1 id="ch-tools-util-linux" role="wrap">
+<sect1 id="ch-tools-util-linux" role="wrap" revision="systemd">
   <?dbhtml filename="util-linux.html"?>
 
   <sect1info condition="script">

--- a/chapter06/chapter06.xml
+++ b/chapter06/chapter06.xml
@@ -78,8 +78,6 @@
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="libpipeline.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="make.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="patch.xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="util-linux.xml"/>
-  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="e2fsprogs.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="man-db.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="tar.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="texinfo.xml"/>
@@ -88,8 +86,9 @@
   <!-- systemd only -->
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="systemd.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="dbus.xml"/>
-  <!-- props needs libsystemd -->
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="procps.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="util-linux.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="e2fsprogs.xml"/>
 
   <!-- sysv only -->
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="sysklogd.xml"/>

--- a/chapter06/systemd.xml
+++ b/chapter06/systemd.xml
@@ -41,6 +41,14 @@
 
    <para>Создайте символическую ссылку, чтобы обойти проблему из-за отсутствия программы xsltproc:</para>
 	<screen><userinput remap="pre">ln -sf /tools/bin/true /usr/bin/xsltproc</userinput></screen>
+
+<para>Поскольку мы еще не установили финальную версию Util-Linux,
+     необходимо создать символические ссылки на библиотеки в необходимом месте:</para>
+
+<screen><userinput remap="pre">for file in /tools/lib64/lib{blkid,mount,uuid}*; do
+    ln -sf $file /usr/lib/
+done</userinput></screen>
+
    <para>Выполните настройку страниц руководств:</para>
 	<screen><userinput remap="pre">tar -xf ../systemd-man-pages-&systemd-version;.tar.xz</userinput></screen>
    <para>Удалите тесты, которые не могут быть собраны в среде chroot:</para>
@@ -57,6 +65,7 @@
     <screen><userinput remap="configure">mkdir -p build
 cd       build
 
+PKG_CONFIG_PATH="/usr/lib/pkgconfig:/tools/lib64/pkgconfig" \
 LANG=en_US.UTF-8                   \
 meson --prefix=/usr                \
       --sysconfdir=/etc            \

--- a/general.ent
+++ b/general.ent
@@ -1,13 +1,13 @@
-<!ENTITY version         "20180920">
+<!ENTITY version         "20180930">
 <!ENTITY short-version   "8.2">  <!-- Used below in &blfs-book;
                                       Change to x.y for release but not -rc releases -->
 <!ENTITY generic-version "development"> <!-- Use "development"  or "x.y[-pre{x}]" -->
 
-<!ENTITY versiond        "20180920-systemd">
+<!ENTITY versiond        "20180930-systemd">
 <!ENTITY short-versiond  "systemd">
 <!ENTITY generic-versiond "systemd">
 
-<!ENTITY releasedate     "20 Сентября, 2018">
+<!ENTITY releasedate     "30 Сентября, 2018">
 
 <!ENTITY copyrightdate   "1999-2018"><!-- jhalfs needs a literal dash, not &ndash; -->
 <!ENTITY milestone       "8.3">


### PR DESCRIPTION
Revision: 11473
Author: dj
Date: 30 сентября 2018 г. 4:14:36
Message:
Restore build of Util-Linux in chapter5 to avoid reciprocal dependency for Systemd.
Moved installation of Util-Linux and E2fsprogs after Procps to satisfy build order in the Systemd book. This has no effect on the SysV book.
----
Modified : /trunk/BOOK/chapter01/changelog.xml
Modified : /trunk/BOOK/chapter05/chapter05.xml
Modified : /trunk/BOOK/chapter05/util-linux.xml
Modified : /trunk/BOOK/chapter06/chapter06.xml
Modified : /trunk/BOOK/chapter06/systemd.xml
Modified : /trunk/BOOK/general.ent


